### PR TITLE
Adds `make deploydocs` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ clean:
 
 package: all
 	$(MAKE) -C ./src package
+
+deploydocs:
+	mkdocs build
+	s3cmd sync site/ s3://redisml.io
+.PHONY: deploydocs


### PR DESCRIPTION
The new make target builds and deploys the documentation to the
website. To run it, first `pip install s3cmd` and configure your
credentials.