### PR TITLE
Fixed wrong LIBDIR path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex;\
     deps="$DEPS";\
     apt-get update; \
 	apt-get install -y --no-install-recommends $deps;\
-    pip install rmtest; 
+    pip install rmtest;
 
 # Build the source
 ADD . /
@@ -21,7 +21,7 @@ RUN set -ex;\
 
 # Package the runner
 FROM redis:latest
-ENV LIBDIR /usr/lib/redis/modules
+ENV LIBDIR /var/lib/redis/modules
 WORKDIR /data
 RUN set -ex;\
     mkdir -p "$LIBDIR";


### PR DESCRIPTION
This fixes:
```
1:M 16 May 19:24:50.929 # Module /var/lib/redis/modules/redis-ml.so failed to load: /var/lib/redis/modules/redis-ml.so: cannot open shared object file: No such file or directory
1:M 16 May 19:24:50.929 # Can't load module from /var/lib/redis/modules/redis-ml.so: server aborting
```